### PR TITLE
Add transactions

### DIFF
--- a/satchel/__init__.py
+++ b/satchel/__init__.py
@@ -1,1 +1,2 @@
 from satchel import constants, model, modelresults, plotting
+from satchel.modelcomparison import SatchelComparison

--- a/satchel/constants.py
+++ b/satchel/constants.py
@@ -30,6 +30,8 @@ DIVS = {
     "TEX": "AL West",
     "TOR": "AL East",
 }
+
+TEAM_ABBRS = DIVS.keys()
 LEAGUE = {team: div.split(" ")[0] for team, div in DIVS.items()}
 DIV = {team: div.split(" ")[1] for team, div in DIVS.items()}
 

--- a/satchel/modelcomparison.py
+++ b/satchel/modelcomparison.py
@@ -1,0 +1,119 @@
+import matplotlib.pyplot as plt
+from os import stat
+from .modelresults import SatchelResults
+
+
+class SatchelComparison:
+    """This class can be used to compare the results of multiple Satchel
+    simulations.
+    """
+
+    def __init__(self, res1: SatchelResults, res2: SatchelResults) -> None:
+        """[summary]
+
+        Parameters
+        ----------
+        res1 : SatchelResults
+            The baseline results to compare to
+        res2 : SatchelResults
+            The new results, changed as a result of some transaction
+        """
+        if res1.seed != res2.seed:
+            print(
+                (
+                    "WARNING: The seeds used for each model are different. "
+                    "For the most accurate comparisons, use the same seed for both"
+                )
+            )
+
+        # find the differences between all the teams
+        self.res1 = res1
+        self.res2 = res2
+        for table in [
+            "season_summary",
+            "alwest",
+            "alcentral",
+            "aleast",
+            "nlwest",
+            "nlcentral",
+            "nleast",
+        ]:
+            diffs = self._get_diffs(table)
+            setattr(self, table, diffs)
+        self.season_summary.set_index("Team", inplace=True)
+
+    def win_dist_chart(self, team, sim1_label, sim2_label):
+        # find the distribution of wins for each simulation
+        wins1 = (
+            self.res1.results_df["wins"][self.res1.results_df["Team"] == team]
+            .value_counts(normalize=True)
+            .reset_index()
+            .sort_values("index")
+        )
+        wins2 = (
+            self.res2.results_df["wins"][self.res2.results_df["Team"] == team]
+            .value_counts(normalize=True)
+            .reset_index()
+            .sort_values("index")
+        )
+        # get changes in important variables
+        wspct = self.season_summary["Win WS (%)"].loc[team]
+        playoffpct = self.season_summary["Make Playoffs (%)"].loc[team]
+        divpct = self.season_summary["Win Division (%)"].loc[team]
+        meanwins = self.season_summary["Mean Wins"].loc[team]
+
+        # create figure
+        fig, ax = plt.subplots(2)
+        ax[0].plot(wins1["index"], wins1["wins"], color="blue", label=sim1_label)
+        mean_wins1 = (wins1["index"] * wins1["wins"]).sum()
+        ax[0].vlines(mean_wins1, 0, wins1["wins"].max(), color="blue", alpha=0.5)
+        ax[0].plot(wins2["index"], wins2["wins"], color="red", label=sim2_label)
+        mean_wins2 = (wins2["index"] * wins2["wins"]).sum()
+        ax[0].vlines(mean_wins2, 0, wins2["wins"].max(), color="red", alpha=0.5)
+        ax[0].legend(loc="upper left")
+        ax[0].set_ylim(ymin=0)
+        ax[0].set_xlabel("Wins")
+        ax[0].set_ylabel("Frequency")
+        ax[0].set_title("Wins Distribution")
+
+        # text description of season changes
+        items = [
+            (wspct, "World Series Odds"),
+            (playoffpct, "Playoff Odds"),
+            (divpct, "Division Winner Odds"),
+            (meanwins, "Expected Wins"),
+        ]
+        yval = 0.8
+        for var, name in items:
+            ax[1].text(0.0, yval, name, size=15)
+            color = "green"
+            arrow = r"$\blacktriangle$"
+            if var < 0:
+                color = "red"
+                arrow = r"$\blacktriangledown$"
+            ax[1].text(0.55, yval, arrow, color=color, size=20)
+            varstr = f"{abs(var):.2f}%".rjust(6, "0")
+            if name == "Expected Wins":
+                varstr = f"{abs(var):.2f}".rjust(5, "0")
+            ax[1].text(0.6, yval, varstr, color=color, size=15)
+            yval -= 0.2
+
+        ax[1].spines["top"].set_visible(False)
+        ax[1].spines["right"].set_visible(False)
+        ax[1].spines["left"].set_visible(False)
+        ax[1].spines["bottom"].set_visible(False)
+        ax[1].xaxis.set_ticks([])
+        ax[1].yaxis.set_ticks([])
+        fig.tight_layout()
+
+        return fig
+
+    ####### Private methods #######
+
+    def _get_diffs(self, table):
+        tbl1 = getattr(self.res1, table)
+        tbl2 = getattr(self.res2, table)
+        diff = tbl2.select_dtypes("number") - tbl1.select_dtypes("number")
+        diff.insert(0, "Team", tbl1["Team"])
+
+        return diff

--- a/satchel/modelresults.py
+++ b/satchel/modelresults.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from dataclasses import dataclass
 from collections import Counter
+from typing import Union
 from . import plotting
 from . import constants
 
@@ -23,6 +24,7 @@ class SatchelResults:
     merged_schedule: pd.DataFrame
     noise: dict  # the noise added to each team's talent in every season
     full_seasons: list  # full season results for each simulation
+    seed: Union[int, None]  # seed used for the simulation
 
     def __post_init__(self):
         """Set all of the default values calculated from the results"""

--- a/satchel/utils.py
+++ b/satchel/utils.py
@@ -1,0 +1,26 @@
+"""
+Utility functions for Satchel
+"""
+import pandas as pd
+from pybaseball import playerid_lookup
+
+
+def player_id_lookup(last=None, first=None, fuzzy=False):
+    """Find a player's FanGraphs ID
+
+    Parameters
+    ----------
+    last : str, optional
+        Player last name, by default None
+    first : str, optional
+        Player first name, by default None
+    fuzzy : bool, optional
+        If an exact match isn't found, return 5 closest names, by default False
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with the player names and FanGraphs IDs that match the search
+    """
+    res = playerid_lookup(last, first, fuzzy)
+    return res[["name_last", "name_first", "key_fangraphs"]].copy()


### PR DESCRIPTION
This PR adds the ability to include transactions in your simulations. Transactions are included by passing a dictionary with key/value pairs that specify the transaction being made. The key in the dictionary is the FanGraphs ID for a player and the value is their new team. To run a simulation with Jacob deGrom traded to Houston, you'd use:

```python
from stachel.model import Satchel

mod1 = Satchel(transactions={'10954': 'HOU'})
res 1 = mod1.simulate()
```

Still to come on this PR are some checks to make sure the transaction is allowed (e.g. verifying the new team specified exists) and functions to make it easy to view the effects of a trade.