### PR TITLE
Allow mid-season transactions

### DIFF
--- a/satchel/model.py
+++ b/satchel/model.py
@@ -2,7 +2,6 @@
 This moduel contains the heart of satchel. All of the season will be simulated
 from this main class
 """
-import pdb
 import pandas as pd
 import numpy as np
 import difflib
@@ -88,21 +87,6 @@ class Satchel:
         SatchelResults
             Instance of the SatchelResults class.
         """
-        # # merge schedule and WAR data to get our dataset for simulations
-        # data = pd.merge(
-        #     self.schedule,
-        #     self.talent[["Team", "talent"]],
-        #     left_on="away",
-        #     right_on="Team",
-        # )
-        # data = pd.merge(
-        #     data, self.talent[["Team", "talent"]], left_on="home", right_on="Team"
-        # )
-        # # clean up data after merge
-        # data.drop(["Team_x", "Team_y"], axis=1, inplace=True)
-        # data.rename(
-        #     columns={"talent_x": "away_talent", "talent_y": "home_talent"}, inplace=True
-        # )
         # counters to track outcomes
         ws_counter = Counter()  # world series championships
         league_counter = Counter()  # league championships
@@ -528,11 +512,6 @@ class Satchel:
             .reset_index()
             .rename({"away": "Team", "away_total": "final_total"}, axis=1)
         )
-        # import pdb
-
-        # pdb.set_trace()
         talent = talent.merge(finaldf, on="Team")
-        # import pdb
 
-        # pdb.set_trace()
         return talent


### PR DESCRIPTION
This PR changes a good chunk of the internal logic behind calculating each team's talent level and the transaction logic added in #5 to allow for transactions to happen at any point in the season. The new format for transactions is:

```python
{player_id: {'date': 'YYYY-MM-DD', 'team': 'new_team'}}
```
As an example, here is how you would send Jacob deGrom to Houston at the start of the year and at the trade deadline:

```python
from satchel.model import Satchel
from satchel import SatchelComparison
mod1 = Satchel(seed=123)
res1 = mod1.simulate(10)
# start of the year
mod2 = Satchel(seed=123, transactions={'10954': {'team': 'HOU', 'date': '2021-04-01'}})
res2 = mod2.simulate(10)
# trade deadline
mod3 = Satchel(seed=123, transactions={'10954': {'team': 'HOU', 'date': '2021-07-31'}})
res3 = mod3.simulate()
```
And we can use the comparison tool from #5 to see the different effects:

```python
comp = SatchelComparison(res1, res2)
comp.win_dist_chart('HOU', 'Base', 'deGrom')
```
<img width="427" alt="Screen Shot 2021-11-25 at 10 56 58 PM" src="https://user-images.githubusercontent.com/20684675/143529077-56e89220-2c75-4fbf-aa14-56344438e965.png">

```python
comp2 = SatchelComparison(res1, res3)
comp2.win_dist_chart('HOU', 'Base', 'deGrom')
```
<img width="424" alt="Screen Shot 2021-11-25 at 10 57 57 PM" src="https://user-images.githubusercontent.com/20684675/143529171-8201559c-6e6a-4eb0-b717-d069d5fd143d.png">

Is this the most efficient way to do this? Maybe not, but it doesn't add to the run time too much. Does it work? I'm pretty sure. This is one of those situations where having unit testing would come in handy.

