### PR TITLE
Fix end of season simulation bug

### DIFF
--- a/satchel/model.py
+++ b/satchel/model.py
@@ -337,19 +337,19 @@ class Satchel:
         wins.rename(columns={"wins": "index", "count": "wins"}, inplace=True)
         losses = loser.value_counts().reset_index()
         losses.rename(columns={"losses": "index", "count": "losses"}, inplace=True)
-        # ensure that teams will always be in the same order
         # outer merge because during simulations late in the season not all teams
         # will appear in both wins and losses if using the current standings.
         # Some will win or lose all of their games, leaving them out of the
-        # other series
+        # other DataFrame
         results = pd.merge(wins, losses, on="index", how="outer").fillna(0)
         # merge on season-to-date results
         if isinstance(current_standings, pd.DataFrame):
-            results = results.merge(current_standings, on="index")
+            results = results.merge(current_standings, on="index", how="outer")
             results["wins"] += results["W"]
             results["losses"] += results["L"]
             results = results.filter(["index", "wins", "losses"], axis="columns")
         assert results.shape[0] == len(self.teams)
+        # use merge sort to ensure that teams will always be in the same order
         results = results.sort_values(
             ["wins", "index"], ascending=False, kind="mergesort"
         )

--- a/satchel/tests/test_model.py
+++ b/satchel/tests/test_model.py
@@ -42,9 +42,7 @@ def test_model(curpath, schedule2021, batter_projections, pitcher_projections):
     # ensure that total projections are always 162 games total
     mod = Satchel(seed=123)
     res = mod.simulate(100)
-    assert all(
-        res.season_summary[["Projected Wins", "Projected Losses"]].sum(axis=1) == 162
-    )
+    assert all(res.season_summary[["Mean Wins", "Mean Losses"]].sum(axis=1) == 162)
 
 
 def test_transaction(


### PR DESCRIPTION
When using the current season results to date and only simulating the remaining schedule, it's possible for a team to either win or lose all of their simulated games when the number of remaining games is small. This results in them being excluded from the final results for that season.

This results fixes that bug by switching from an inner to an outer join when merging the wins and losses DataFrames so that all teams are included.